### PR TITLE
Fix use() so local clients can use it

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,7 @@ module.exports = {
   version: '1.0.0',
   manifest: require('./manifest.json'),
   permissions: {
-    master: {allow: ['create']},
-    //temp: {allow: ['use']}
+    master: {allow: ['create', 'use']},
   },
   init: function (server, config) {
     var codes = {}, codesDB


### PR DESCRIPTION
I'm hitting a but where Oasis as a pub can't actually accept pub invites because it's connecting to Secret-Stack via MuxRPC, and authenticating with ssb-master. I think this plugin should allow `use()` to be used via `master`, right? I don't think I'm familiar with the `master` property but it sounds like maybe it's limiting the allowed methods to the contents of the array? I don't think I understand why we'd limit these methods at all.

Maybe the `master` key can just be removed?