### PR TITLE
Update npm dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "ssb-invite",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "abstract-leveldown": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.3.tgz",
-      "integrity": "sha512-jzewKKpZbaYUa6HTThnrl+GrJhzjEAeuc7hTVpZdzg7kupXZFoqQDFwyOwLNbmJKJlmzw8yiipMPkDiuKkT06Q==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.2.tgz",
+      "integrity": "sha512-/a+Iwj0rn//CX0EJOasNyZJd2o8xur8Ce9C57Sznti/Ilt/cb6Qd8/k98A4ZOklXgTG+iAYYUs1OTG0s1eH+zQ==",
       "requires": {
         "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
         "xtend": "~4.0.0"
       }
     },
@@ -20,9 +21,9 @@
       "dev": true
     },
     "atomic-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-2.0.0.tgz",
-      "integrity": "sha512-8acsmdYLYCzawXHRV+ryvRppE6dkkPrSywy6wiCzjp2T0wX4rzxw1tJbPgUgZPdi3OQ3AMvvZ3Anrnq6bERvLg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-2.0.1.tgz",
+      "integrity": "sha512-9JCWojeLDF8UhEv2UJlLlPGsLEs+EBnfB+kOhsvmFI2QilVrnIsAwr7YnF8lLEVuxB+HxFhvGK+ax0Y8Eh/BKA==",
       "dev": true,
       "requires": {
         "flumecodec": "0.0.1",
@@ -198,11 +199,11 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deferred-leveldown": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.0.1.tgz",
-      "integrity": "sha512-BXohsvTedWOLkj2n/TY+yqVlrCWa2Zs8LSxh3uCAgFOru7/pjxKyZAexGa1j83BaKloER4PqUyQ9rGPJLt9bqA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
+      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
       "requires": {
-        "abstract-leveldown": "~6.0.0",
+        "abstract-leveldown": "~6.2.1",
         "inherits": "^2.0.3"
       }
     },
@@ -225,6 +226,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+    },
+    "dotignore": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "dynamic-dijkstra": {
       "version": "1.0.2",
@@ -260,11 +270,11 @@
       }
     },
     "encoding-down": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.0.2.tgz",
-      "integrity": "sha512-oAEANslmNb64AF4kvHXjTxB7KecwD7X0qf8MffMfhpjP6gjGcnCTOkRgps/1yUNeR4Bhe6ckN6aAzZz+RIYgTw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
       "requires": {
-        "abstract-leveldown": "^6.0.0",
+        "abstract-leveldown": "^6.2.1",
         "inherits": "^2.0.3",
         "level-codec": "^9.0.0",
         "level-errors": "^2.0.0"
@@ -279,23 +289,28 @@
       }
     },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.0",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
       }
     },
     "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -307,11 +322,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
       "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
-    },
-    "fast-future": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
-      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
     },
     "flumecodec": {
       "version": "0.0.0",
@@ -360,559 +370,25 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minipass": {
-          "version": "2.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^4.1.0",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.7.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -924,9 +400,9 @@
       }
     },
     "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "heap": {
@@ -980,10 +456,16 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
       "dev": true
     },
     "is-canonical-base64": {
@@ -992,9 +474,9 @@
       "integrity": "sha512-o6t/DwgEapC0bsloqtegAQyZzQXaQ5+8fzsyf2KmLqupC2ifLFq/lMQiFCJeGpdSrK1o6GL+WW2lRU050lLlFg=="
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
     "is-electron": {
@@ -1003,27 +485,22 @@
       "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "^1.0.3"
       }
     },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
       }
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-valid-domain": {
       "version": "0.0.9",
@@ -1048,13 +525,13 @@
       }
     },
     "level": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/level/-/level-5.0.1.tgz",
-      "integrity": "sha512-wcak5OQeA4rURGacqS62R/xNHjCYnJSQDBOlm4KNUGJVE9bWv2B04TclqReYejN+oD65PzD4FsqeWoI5wNC5Lg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-6.0.0.tgz",
+      "integrity": "sha512-3oAi7gXLLNr7pHj8c4vbI6lHkXf35m8qb7zWMrNTrOax6CXBVggQAwL1xnC/1CszyYrW3BsLXsY5TMgTxtKfFA==",
       "requires": {
-        "level-js": "^4.0.0",
-        "level-packager": "^5.0.0",
-        "leveldown": "^5.0.0",
+        "level-js": "^5.0.0",
+        "level-packager": "^5.1.0",
+        "leveldown": "^5.4.0",
         "opencollective-postinstall": "^2.0.0"
       }
     },
@@ -1077,46 +554,45 @@
       }
     },
     "level-iterator-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.1.tgz",
-      "integrity": "sha512-pSZWqXK6/yHQkZKCHrR59nKpU5iqorKM22C/BOHTb/cwNQ2EOZG+bovmFFGcOgaBoF3KxqJEI27YwewhJQTzsw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
+      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.0.2",
-        "xtend": "^4.0.0"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0",
+        "xtend": "^4.0.2"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "xtend": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         }
       }
     },
     "level-js": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/level-js/-/level-js-4.0.1.tgz",
-      "integrity": "sha512-m5JRIyHZn5VnCCFeRegJkn5bQd3MJK5qZX12zg3Oivc8+BUIS2yFS6ANMMeHX2ieGxucNvEn6/ZnyjmZQLLUWw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.1.tgz",
+      "integrity": "sha512-Jse0/UP2qFl2YN8HISnxwQIRHNM3vJLafkTKjw4tZs9Vi8VGUFVmGvg/WMn5To/6KHyYJTXZvUzuouoaZuPGXA==",
       "requires": {
-        "abstract-leveldown": "~6.0.1",
+        "abstract-leveldown": "~6.2.1",
         "immediate": "~3.2.3",
         "inherits": "^2.0.3",
-        "ltgt": "^2.1.2",
-        "typedarray-to-buffer": "~3.1.5"
+        "ltgt": "^2.1.2"
       }
     },
     "level-packager": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.0.1.tgz",
-      "integrity": "sha512-tigB8g7xnFE5es2d/OmGJvcJC9S+FQfJnnULSLbPr53/ABPIaCarCxofkwdBhnJxjLZCNvj/Je6luFj/XeuaUQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
       "requires": {
-        "encoding-down": "^6.0.0",
-        "levelup": "^4.0.0"
+        "encoding-down": "^6.3.0",
+        "levelup": "^4.3.2"
       }
     },
     "level-post": {
@@ -1227,32 +703,47 @@
         }
       }
     },
-    "leveldown": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.0.3.tgz",
-      "integrity": "sha512-isfWtOQIXbGbQRI8nmU9FqCZM0klmqTAOFi0vF6G/D0O1ZgxLrSh6Xd4Zj9iVQfGt6+8jpYwkRbN07VLrxRM8w==",
+    "level-supports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
       "requires": {
-        "abstract-leveldown": "~6.0.3",
-        "fast-future": "~1.0.2",
-        "napi-macros": "~1.8.1",
-        "node-gyp-build": "~3.8.0"
+        "xtend": "^4.0.2"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        }
+      }
+    },
+    "leveldown": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.4.1.tgz",
+      "integrity": "sha512-3lMPc7eU3yj5g+qF1qlALInzIYnkySIosR1AsUKFjL9D8fYbTLuENBAeDRZXIG4qeWOAyqRItOoLu2v2avWiMA==",
+      "requires": {
+        "abstract-leveldown": "~6.2.1",
+        "napi-macros": "~2.0.0",
+        "node-gyp-build": "~4.1.0"
       },
       "dependencies": {
         "node-gyp-build": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.8.0.tgz",
-          "integrity": "sha512-bYbpIHyRqZ7sVWXxGpz8QIRug5JZc/hzZH4GbdT9HTZi6WmKCZ8GLvP8OZ9TTiIBvwPFKgtGrlWQSXDAvYdsPw=="
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
+          "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ=="
         }
       }
     },
     "levelup": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.0.1.tgz",
-      "integrity": "sha512-l7KXOkINXHgNqmz0v9bxvRnMCUG4gmShFrzFSZXXhcqFnfvKAW8NerVsTICpZtVhGOMAmhY6JsVoVh/tUPBmdg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.3.2.tgz",
+      "integrity": "sha512-cRTjU4ktWo59wf13PHEiOayHC3n0dOh4i5+FHr4tv4MX9+l7mqETicNq3Aj07HKlLdk0z5muVoDL2RD+ovgiyA==",
       "requires": {
-        "deferred-leveldown": "~5.0.0",
+        "deferred-leveldown": "~5.3.0",
         "level-errors": "~2.0.0",
         "level-iterator-stream": "~4.0.0",
+        "level-supports": "~1.0.0",
         "xtend": "~4.0.0"
       }
     },
@@ -1268,6 +759,11 @@
       "requires": {
         "libsodium": "0.7.4"
       }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "looper": {
       "version": "2.0.0",
@@ -1379,34 +875,24 @@
       }
     },
     "muxrpc": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.2.tgz",
-      "integrity": "sha512-1wRnouHgHO3JYN3xbyzQGTFsd/wo12/zaikmQusP8ma+lmL+ewNvuvuwKSEJasKQTRnbTwbzh/OPdt9N76CA4g==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.5.0.tgz",
+      "integrity": "sha512-8kCo33LTYPYWAJGi2Ag2ukcluoNqJIe6Ay9QtGf7EXAUlTuMSA0HqR7jCbXt7DQPR4Alu/T3/mOguuERpDMGcw==",
       "requires": {
         "explain-error": "^1.0.1",
         "packet-stream": "~2.0.0",
         "packet-stream-codec": "^1.1.1",
         "pull-goodbye": "0.0.2",
-        "pull-stream": "^3.2.3"
+        "pull-stream": "^3.6.10"
       }
     },
     "muxrpc-validation": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-3.0.0.tgz",
-      "integrity": "sha1-47bAMaetOA8CrWfZMG1PGz+NNdY=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-3.0.2.tgz",
+      "integrity": "sha512-iWo/23xFnl+IGeX+LlfwoVKtyY4volPSodf3nwPScPgxjws4k2ZUozPG98OouMA0yn0JamqApjRw7eqLrzyV2A==",
       "requires": {
-        "pull-stream": "^2.28.3",
-        "zerr": "^1.0.1"
-      },
-      "dependencies": {
-        "pull-stream": {
-          "version": "2.28.4",
-          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
-          "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
-          "requires": {
-            "pull-core": "~1.1.0"
-          }
-        }
+        "pull-stream": "^3.6.11",
+        "zerr": "^1.0.4"
       }
     },
     "nan": {
@@ -1415,9 +901,9 @@
       "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
     },
     "napi-macros": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-1.8.2.tgz",
-      "integrity": "sha512-Tr0DNY4RzTaBG2W2m3l7ZtFuJChTH6VZhXVhkGGjF/4cZTt+i8GcM9ozD+30Lmr4mDoZ5Xx34t2o4GJqYWDGcg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
     },
     "nearley": {
       "version": "2.16.0",
@@ -1445,9 +931,15 @@
       }
     },
     "object-inspect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
       "dev": true
     },
     "object-keys": {
@@ -1455,6 +947,18 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
     },
     "observ": {
       "version": "0.2.0",
@@ -1570,11 +1074,6 @@
       "integrity": "sha1-3x1YDicXV7qay666IN4kIdZg1hg=",
       "dev": true
     },
-    "pull-core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
-      "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo="
-    },
     "pull-defer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
@@ -1641,9 +1140,9 @@
       }
     },
     "pull-many": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/pull-many/-/pull-many-1.0.8.tgz",
-      "integrity": "sha1-Pa3ZttFWxUVyG9qNAAPdjqoGKT4=",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/pull-many/-/pull-many-1.0.9.tgz",
+      "integrity": "sha512-+jUydDVlj/HsvtDqxWMSsiRq3B0HVo7RhBV4C0p2nZRS3mFTUEu9SPEBN+B5PMaW8KTnblYhTIaKg7oXgGnj4Q==",
       "dev": true,
       "requires": {
         "pull-stream": "^3.4.5"
@@ -1697,9 +1196,9 @@
       "integrity": "sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw=="
     },
     "pull-stream": {
-      "version": "3.6.11",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.11.tgz",
-      "integrity": "sha512-43brwtqO0OSltctKbW1mgzzKH4TNE8egkW+Y4BFzlDWiG2Ayl7VKr4SeuoKacfgPfUWcSwcPlHsf40BEqNR32A=="
+      "version": "3.6.14",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
+      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
     },
     "pull-through": {
       "version": "1.0.18",
@@ -1765,15 +1264,35 @@
         "strip-json-comments": "~2.0.1"
       }
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
     "relative-url": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
       "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
     },
     "resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
+      "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -1908,41 +1427,60 @@
       "resolved": "https://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz",
       "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc="
     },
+    "ssb-caps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-caps/-/ssb-caps-1.1.0.tgz",
+      "integrity": "sha512-qe3qpvchJ+gnH8M/ge4rpL+7eRbSmsEAzNwHkDdrW06OBcziQ6/KuAdmcR6joxCbNeoAXAZF+inkefgE16okXA=="
+    },
     "ssb-client": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.7.4.tgz",
-      "integrity": "sha512-//zHVdTZ4RTFPl1izXGu6vlinwPhTwio8oJHJ4Zix3AI9L8k6K+Jau9jVwltT1lBfQJmeUIWj7f9X9s8nvOiew==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.9.0.tgz",
+      "integrity": "sha512-5wPrVA82Uk3deV2oiCZEbm1kMp9r/5xTT2VvwwMLZS3fDD9FnLOi0kjUUh3OTP+jGBK7bVHRmnvXIVy6ETnSpA==",
       "requires": {
         "explain-error": "^1.0.1",
         "multicb": "^1.2.1",
         "multiserver": "^3.1.2",
-        "muxrpc": "^6.4.2",
+        "muxrpc": "^6.5.0",
         "pull-hash": "^1.0.0",
         "pull-stream": "^3.6.0",
-        "ssb-config": "^2.3.9",
-        "ssb-keys": "^7.0.13"
+        "ssb-config": "^3.4.4",
+        "ssb-keys": "^7.2.1"
+      },
+      "dependencies": {
+        "ssb-keys": {
+          "version": "7.2.2",
+          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
+          "integrity": "sha512-FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==",
+          "requires": {
+            "chloride": "^2.2.8",
+            "mkdirp": "~0.5.0",
+            "private-box": "^0.3.0"
+          }
+        }
       }
     },
     "ssb-config": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-2.3.9.tgz",
-      "integrity": "sha512-UF+4+khFXILLBqtu9HfrpUwYnDXIdAyJe3u9X4GrApuoakxuSKwaUGakUxLPyo6COyV2brMqufUgf+fDOI8Ftw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.4.4.tgz",
+      "integrity": "sha512-J3fsWb5nS6PqObZLW2tclEz/bkRQ5pcF9goXanYGVsoH71F6W4f5sOnck9szeubI8srNaiL9pa0kPRv/lojHiw==",
       "requires": {
         "deep-extend": "^0.6.0",
-        "non-private-ip": "^1.2.1",
+        "ip": "^1.1.5",
+        "lodash.get": "^4.4.2",
         "os-homedir": "^1.0.1",
-        "rc": "^1.1.6"
+        "rc": "^1.1.6",
+        "ssb-caps": "^1.0.1",
+        "ssb-keys": "^7.1.4"
       }
     },
     "ssb-friends": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-4.1.0.tgz",
-      "integrity": "sha512-Ltvlf0i+9KvVr1xjbRykrl1Ngu7lAvjuKe2vki6KYOTkQOWpSVh/weKT817J4S5ere36tLufq5HfXf5c/LGFuQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-4.1.4.tgz",
+      "integrity": "sha512-rjQP2rLocqnUoiI+SSUehLQwMB4H5TKD13hfnweGVIgAWw4mylbl9bPOuXtTU23ubPkdbSNadlp3uivsCkWLxw==",
       "dev": true,
       "requires": {
         "flumeview-reduce": "^1.3.0",
         "layered-graph": "^1.1.1",
-        "pull-cont": "^0.1.1",
         "pull-flatmap": "0.0.1",
         "pull-notify": "^0.1.1",
         "pull-stream": "^3.6.0",
@@ -1950,9 +1488,9 @@
       }
     },
     "ssb-keys": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.1.6.tgz",
-      "integrity": "sha512-DCl6BTz7zy7fElWgok1aBvYBfe6aUzafW1Q7z5WkpgdT8H90oqXe2l5DyTd7k77yyg82uDSjPOKfPAE9eBqfug==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
+      "integrity": "sha512-FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==",
       "requires": {
         "chloride": "^2.2.8",
         "mkdirp": "~0.5.0",
@@ -1971,9 +1509,9 @@
       }
     },
     "ssb-replicate": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ssb-replicate/-/ssb-replicate-1.3.0.tgz",
-      "integrity": "sha512-FLizJ+eHtGrySb61v3asIKpZkje77a6Cl7ZotUjD3YjNUOC7y+HN0AWaupbiiFiQXDGrIZ0ti0Mr8bHkMOJurQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ssb-replicate/-/ssb-replicate-1.3.2.tgz",
+      "integrity": "sha512-r/34OHn5wDkVUu0UNdKdPjmd3cPDmgknA5nK+gXBZj9ugSDwmdDsfEUavGtA7hlO+He1pC4EXtBa14dqgTqJCg==",
       "dev": true,
       "requires": {
         "deep-equal": "^1.0.1",
@@ -1989,9 +1527,9 @@
       }
     },
     "ssb-server": {
-      "version": "14.1.12",
-      "resolved": "https://registry.npmjs.org/ssb-server/-/ssb-server-14.1.12.tgz",
-      "integrity": "sha512-a8b7UEsKzmpD6rKNhrzbYATTUlxFIByBmDxFjGtylTblnVgdA3d4e1ISLcyTbbCW3jOCjxXzk60+ZtbSIK7OYg==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/ssb-server/-/ssb-server-15.2.0.tgz",
+      "integrity": "sha512-iOzvg1HSRuT7k56AdKbeVnqeyc8iTZNMqIcbOv+zc4GBZODc37vtxtv688EnyNVCWuLnBsQBH3HlAYrcolQE7g==",
       "dev": true,
       "requires": {
         "bash-color": "~0.0.3",
@@ -2010,7 +1548,7 @@
         "multiserver": "^3.3.1",
         "multiserver-address": "^1.0.1",
         "muxrpc-validation": "^3",
-        "muxrpcli": "^1.0.0",
+        "muxrpcli": "3",
         "mv": "^2.1.1",
         "osenv": "^0.1.5",
         "pull-cat": "~1.1.5",
@@ -2019,22 +1557,30 @@
         "pull-pushable": "^2.2.0",
         "pull-stream": "^3.6.2",
         "rimraf": "^2.4.2",
-        "secret-stack": "^6.0.2",
-        "ssb-blobs": "^1.1.13",
-        "ssb-client": "^4.7.1",
+        "secret-stack": "^6.3.1",
+        "ssb-blobs": "1.2.2",
+        "ssb-caps": "^1.0.1",
+        "ssb-client": "^4.7.9",
         "ssb-config": "^3.2.5",
-        "ssb-db": "^19.1.0",
+        "ssb-db": "19.2.0",
         "ssb-ebt": "^5.6.1",
-        "ssb-friends": "^4.0.0",
-        "ssb-gossip": "^1.0.6",
-        "ssb-invite": "^2.0.3",
+        "ssb-friends": "^4.1.0",
+        "ssb-gossip": "^1.1.0",
+        "ssb-invite": "^2.1.2",
         "ssb-keys": "^7.1.1",
-        "ssb-links": "^3.0.2",
-        "ssb-ooo": "^1.2.2",
-        "ssb-query": "^2.1.0",
+        "ssb-links": "^3.0.4",
+        "ssb-local": "^1.0.0",
+        "ssb-logging": "^1.0.0",
+        "ssb-master": "^1.0.2",
+        "ssb-no-auth": "^1.0.0",
+        "ssb-onion": "^1.0.0",
+        "ssb-ooo": "^1.3.0",
+        "ssb-plugins": "1.0.0",
+        "ssb-query": "^2.4.0",
         "ssb-ref": "^2.13.9",
-        "ssb-replicate": "^1.2.1",
-        "ssb-ws": "^5.1.1",
+        "ssb-replicate": "^1.3.0",
+        "ssb-unix-socket": "^1.0.0",
+        "ssb-ws": "^6.2.1",
         "stream-to-pull-stream": "^1.6.10",
         "zerr": "^1.0.0"
       },
@@ -2048,11 +1594,11 @@
           }
         },
         "@babel/generator": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+          "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
           "requires": {
-            "@babel/types": "^7.4.0",
+            "@babel/types": "^7.4.4",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.11",
             "source-map": "^0.5.0",
@@ -2078,11 +1624,11 @@
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
-          "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
           "requires": {
-            "@babel/types": "^7.4.0"
+            "@babel/types": "^7.4.4"
           }
         },
         "@babel/highlight": {
@@ -2124,40 +1670,40 @@
           }
         },
         "@babel/parser": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-          "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ=="
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
+          "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w=="
         },
         "@babel/template": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
-          "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+          "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.4.0",
-            "@babel/types": "^7.4.0"
+            "@babel/parser": "^7.4.4",
+            "@babel/types": "^7.4.4"
           }
         },
         "@babel/traverse": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
-          "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
+          "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.0",
+            "@babel/generator": "^7.4.4",
             "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.0",
-            "@babel/parser": "^7.4.3",
-            "@babel/types": "^7.4.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.4.4",
+            "@babel/types": "^7.4.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.11"
           }
         },
         "@babel/types": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.11",
@@ -2165,39 +1711,27 @@
           }
         },
         "abstract-leveldown": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.3.tgz",
+          "integrity": "sha512-jzewKKpZbaYUa6HTThnrl+GrJhzjEAeuc7hTVpZdzg7kupXZFoqQDFwyOwLNbmJKJlmzw8yiipMPkDiuKkT06Q==",
           "dev": true,
           "requires": {
+            "level-concat-iterator": "~2.0.0",
             "xtend": "~4.0.0"
           }
         },
         "aligned-block-file": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.2.0.tgz",
-          "integrity": "sha512-kBF1xv3mlGBuMxJ/5IrbQD43q7Pi3yyM5IedXxuTbbc6QV3vEnZK18fH9MadoA5LvIKkgCVWRPEMlHemfz5tMg==",
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.2.2.tgz",
+          "integrity": "sha512-2Sy0hWhifVb8ycNFJgicL8fDPL2Ct1r62XOVxXnykn36z22MPZwnQlCmB2viQlY/lwfuO67GaQjUZ0rJgdVP7Q==",
           "dev": true,
           "requires": {
             "hashlru": "^2.1.0",
             "int53": "^1.0.0",
             "mkdirp": "^0.5.1",
             "obv": "^0.0.1",
+            "rwlock": "^5.0.0",
             "uint48be": "^2.0.1"
-          },
-          "dependencies": {
-            "int53": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/int53/-/int53-1.0.0.tgz",
-              "integrity": "sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w==",
-              "dev": true
-            },
-            "uint48be": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/uint48be/-/uint48be-2.0.1.tgz",
-              "integrity": "sha512-LQvWofTo3RCz+XaQR3VNch+dDFwpIvWr/98imhQne++vFhpQP16YAC/a8w9N00Heqqra00ACjHT18cgvn5H+bg==",
-              "dev": true
-            }
           }
         },
         "ansi-escapes": {
@@ -2229,26 +1763,10 @@
           }
         },
         "append-batch": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.1.tgz",
-          "integrity": "sha1-kiSFjlVpl8zAfxHx7poShTKqDSU=",
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.2.tgz",
+          "integrity": "sha1-1zm0UDiIJF1Hkz1HVisRSf+d+Lc=",
           "dev": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-          "dev": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-          "dev": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
         },
         "arr-diff": {
           "version": "2.0.0",
@@ -2348,9 +1866,9 @@
           }
         },
         "bail": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
-          "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+          "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
           "dev": true
         },
         "balanced-match": {
@@ -2450,20 +1968,39 @@
           "integrity": "sha512-RHFP0AdU6KAB0CCZsRMU2CJTk2EpL8GLURT+4gilpjr1f/7M91FgUMnXuQLmf3OKLet34gjuNFwO7e4agdX5pw==",
           "dev": true
         },
-        "bindings": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
-          "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
-          "dev": true
-        },
         "bl": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+          "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
+            "readable-stream": "~1.0.26"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "dev": true
+            }
           }
         },
         "blake2s": {
@@ -2497,28 +2034,6 @@
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/broadcast-stream/-/broadcast-stream-0.2.2.tgz",
           "integrity": "sha1-eee7FKmrunf3KsklgiAkKo/TkZ0=",
-          "dev": true
-        },
-        "buffer-alloc": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-          "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-          "dev": true,
-          "requires": {
-            "buffer-alloc-unsafe": "^1.1.0",
-            "buffer-fill": "^1.0.0"
-          }
-        },
-        "buffer-alloc-unsafe": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-          "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-          "dev": true
-        },
-        "buffer-fill": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-          "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
           "dev": true
         },
         "buffer-from": {
@@ -2603,9 +2118,9 @@
           }
         },
         "ccount": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
-          "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
+          "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
           "dev": true
         },
         "chalk": {
@@ -2622,27 +2137,27 @@
           }
         },
         "character-entities": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
-          "integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==",
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+          "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==",
           "dev": true
         },
         "character-entities-html4": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
-          "integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
+          "integrity": "sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg==",
           "dev": true
         },
         "character-entities-legacy": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
-          "integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+          "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==",
           "dev": true
         },
         "character-reference-invalid": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
-          "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+          "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==",
           "dev": true
         },
         "charwise": {
@@ -2687,12 +2202,6 @@
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.0.0"
           }
-        },
-        "chownr": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
-          "dev": true
         },
         "class-utils": {
           "version": "0.3.6",
@@ -2745,9 +2254,9 @@
           "dev": true
         },
         "collapse-white-space": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
-          "integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw==",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
+          "integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==",
           "dev": true
         },
         "collection-visit": {
@@ -2789,6 +2298,23 @@
             "typewiselite": "^1.0.0"
           }
         },
+        "compatibility": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/compatibility/-/compatibility-1.0.0.tgz",
+          "integrity": "sha512-SJztBRqXAddo8gBxYjXLgvLvdCveuTNzDhNl7layXezAmHUIt2JKTCGZjUsVukFNowFI108TT3T3dbvBA5+bXg==",
+          "requires": {
+            "debug": "^4.1.1",
+            "npm-install-package": "^2.1.0",
+            "semver": "^6.1.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
+              "integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ=="
+            }
+          }
+        },
         "component-emitter": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -2812,12 +2338,6 @@
             "readable-stream": "^2.2.2",
             "typedarray": "^0.0.6"
           }
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
         },
         "cont": {
           "version": "1.0.3",
@@ -2946,15 +2466,6 @@
           "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
           "dev": true
         },
-        "decompress-response": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-          "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-          "dev": true,
-          "requires": {
-            "mimic-response": "^1.0.0"
-          }
-        },
         "deep-equal": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -2968,12 +2479,12 @@
           "dev": true
         },
         "deferred-leveldown": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
-          "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.0.1.tgz",
+          "integrity": "sha512-BXohsvTedWOLkj2n/TY+yqVlrCWa2Zs8LSxh3uCAgFOru7/pjxKyZAexGa1j83BaKloER4PqUyQ9rGPJLt9bqA==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~5.0.0",
+            "abstract-leveldown": "~6.0.0",
             "inherits": "^2.0.3"
           }
         },
@@ -3045,12 +2556,6 @@
           "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
           "dev": true
         },
-        "delegates": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-          "dev": true
-        },
         "detab": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/detab/-/detab-1.0.2.tgz",
@@ -3059,12 +2564,6 @@
           "requires": {
             "repeat-string": "^1.5.2"
           }
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-          "dev": true
         },
         "discontinuous-range": {
           "version": "1.0.0",
@@ -3257,25 +2756,15 @@
           }
         },
         "encoding-down": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
-          "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.0.2.tgz",
+          "integrity": "sha512-oAEANslmNb64AF4kvHXjTxB7KecwD7X0qf8MffMfhpjP6gjGcnCTOkRgps/1yUNeR4Bhe6ckN6aAzZz+RIYgTw==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "^5.0.0",
+            "abstract-leveldown": "^6.0.0",
             "inherits": "^2.0.3",
             "level-codec": "^9.0.0",
-            "level-errors": "^2.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "end-of-stream": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-          "dev": true,
-          "requires": {
-            "once": "^1.4.0"
+            "level-errors": "^2.0.0"
           }
         },
         "epidemic-broadcast-trees": {
@@ -3363,12 +2852,6 @@
           "requires": {
             "fill-range": "^2.1.0"
           }
-        },
-        "expand-template": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-          "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-          "dev": true
         },
         "explain-error": {
           "version": "1.0.4",
@@ -3469,9 +2952,9 @@
           }
         },
         "flumedb": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-1.0.6.tgz",
-          "integrity": "sha512-XUAxCNnVdxuiUnswQ6bsYb/c4ObX0LupwDGI1GjowN5hQne0BTiB8p74dXr3nbx69WwE/4fNbFcLmuvWIcx6Tg==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-1.1.0.tgz",
+          "integrity": "sha512-Bwol+72GU5z2DxZlnaxUA9A8qaRcQcdTprmRcgfqn2ldn147ByVh9Zyp90hVGPlo/oEN/yjOBUXcNkK3SYjbgA==",
           "dev": true,
           "requires": {
             "cont": "^1.0.3",
@@ -3483,28 +2966,26 @@
           }
         },
         "flumelog-offset": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.3.2.tgz",
-          "integrity": "sha512-KG0TCb+cWuEvnL44xjBhVNu+jRmJ8Msh2b1krYb4FllLwSbjreaCU/hH3uzv+HmUrtU/EhJepcAu79WxLH3EZQ==",
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.4.2.tgz",
+          "integrity": "sha512-pj8gc3idzbpWjGQPXvRwNdkqtHPx/0olLsyip3u1lULP+LVvcYGYvTt8AU0frKWSFsGST0B8WVh9DrZ5rsEzbg==",
           "dev": true,
           "requires": {
-            "aligned-block-file": "^1.1.2",
-            "append-batch": "^0.0.1",
-            "explain-error": "^1.0.3",
-            "hashlru": "^2.2.0",
-            "int53": "^0.2.4",
+            "aligned-block-file": "^1.2.0",
+            "append-batch": "0.0.2",
+            "hashlru": "^2.3.0",
+            "int53": "^1.0.0",
             "looper": "^4.0.0",
-            "ltgt": "^2.1.3",
             "obv": "0.0.1",
             "pull-cursor": "^3.0.0",
             "pull-looper": "^1.0.0",
-            "uint48be": "^1.0.1"
+            "uint48be": "^2.0.1"
           }
         },
         "flumeview-hashtable": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/flumeview-hashtable/-/flumeview-hashtable-1.0.4.tgz",
-          "integrity": "sha512-4L52hBelX7dYVAQQ9uPjksqxOCxLwI4NsfEG/+sTM423axT2Poq5cnfdvGm3HzmNowzwDIKtdy429r6PbfKEIw==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/flumeview-hashtable/-/flumeview-hashtable-1.1.1.tgz",
+          "integrity": "sha512-73LAN0qF4zVMHMExYhK0z1swDo6FEh/bt1HF5/UnWkgI5JsECXOK2bTokWVU1levtr9bd+IxYChnJKJNnEzD0A==",
           "dev": true,
           "requires": {
             "async-single": "^1.0.5",
@@ -3514,14 +2995,14 @@
           }
         },
         "flumeview-level": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-3.0.8.tgz",
-          "integrity": "sha512-XvHc5diz9PdtzLjLrLtbTw79+Kxm0LqiXkwwushnIBVVTBdREVupTgUQgfuIdZW/WdAr6p3heGPYlf0v89NBrw==",
+          "version": "3.0.13",
+          "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-3.0.13.tgz",
+          "integrity": "sha512-K8sM6AoWVGWps5H/MiqEHxWd0Ts3NtcWEsBjGmC3LD2EPOhrTcDQFn4dVpGAdiZma3RGFRVHE7OTperHrfJnkA==",
           "dev": true,
           "requires": {
             "charwise": "^3.0.1",
             "explain-error": "^1.0.4",
-            "level": "^4.0.0",
+            "level": "^5.0.0",
             "ltgt": "^2.1.3",
             "mkdirp": "^0.5.1",
             "obv": "0.0.1",
@@ -3639,39 +3120,565 @@
             "map-cache": "^0.2.2"
           }
         },
-        "fs-constants": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-          "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-          "dev": true
-        },
         "fs.realpath": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
+        "fsevents": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+          "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1",
+            "node-pre-gyp": "^0.12.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.3.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.2.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.3.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "debug": "^4.1.0",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.12.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.4.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.7.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
           "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
           "dev": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-          "dev": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
         },
         "get-stdin": {
           "version": "4.0.1",
@@ -3682,12 +3689,6 @@
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
           "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-          "dev": true
-        },
-        "github-from-package": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-          "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
           "dev": true
         },
         "glob": {
@@ -3723,9 +3724,9 @@
           }
         },
         "globals": {
-          "version": "11.11.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw=="
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
         },
         "globby": {
           "version": "4.1.0",
@@ -3755,6 +3756,24 @@
           "version": "4.1.15",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
           "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+        },
+        "handlebars": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+          "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+          "requires": {
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            }
+          }
         },
         "has": {
           "version": "1.0.3",
@@ -3789,12 +3808,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
           "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-          "dev": true
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true
         },
         "has-value": {
@@ -3901,6 +3914,12 @@
             "promisize": "^1.1.2"
           }
         },
+        "immediate": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+          "dev": true
+        },
         "increment-buffer": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
@@ -3938,9 +3957,9 @@
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "int53": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz",
-          "integrity": "sha1-XtjXqtbFxlZ8rmmqf/xKEJ7oD4Y=",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/int53/-/int53-1.0.0.tgz",
+          "integrity": "sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w==",
           "dev": true
         },
         "interleavings": {
@@ -3974,15 +3993,15 @@
           }
         },
         "is-alphabetical": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
-          "integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+          "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
           "dev": true
         },
         "is-alphanumerical": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
-          "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+          "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
           "dev": true,
           "requires": {
             "is-alphabetical": "^1.0.0",
@@ -4036,9 +4055,9 @@
           "dev": true
         },
         "is-decimal": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
-          "integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+          "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==",
           "dev": true
         },
         "is-descriptor": {
@@ -4119,9 +4138,9 @@
           }
         },
         "is-hexadecimal": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
-          "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+          "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
           "dev": true
         },
         "is-number": {
@@ -4185,6 +4204,12 @@
             "has-symbols": "^1.0.0"
           }
         },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "dev": true
+        },
         "is-utf8": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -4223,21 +4248,21 @@
           }
         },
         "istanbul-lib-coverage": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
-          "integrity": "sha512-LXTBICkMARVgo579kWDm8SqfB6nvSDKNqIOBEjmJRnL04JvoMHCYGWaMddQnseJYtkEuEvO/sIcOxPLk9gERug=="
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+          "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA=="
         },
         "istanbul-lib-instrument": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.2.0.tgz",
-          "integrity": "sha512-06IM3xShbNW4NgZv5AP4QH0oHqf1/ivFo8eFys0ZjPXHGldHJQWb3riYOKXqmOqfxXBfxu4B+g/iuhOPZH0RJg==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+          "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
           "requires": {
-            "@babel/generator": "^7.0.0",
-            "@babel/parser": "^7.0.0",
-            "@babel/template": "^7.0.0",
-            "@babel/traverse": "^7.0.0",
-            "@babel/types": "^7.0.0",
-            "istanbul-lib-coverage": "^2.0.4",
+            "@babel/generator": "^7.4.0",
+            "@babel/parser": "^7.4.3",
+            "@babel/template": "^7.4.0",
+            "@babel/traverse": "^7.4.3",
+            "@babel/types": "^7.4.0",
+            "istanbul-lib-coverage": "^2.0.5",
             "semver": "^6.0.0"
           },
           "dependencies": {
@@ -4290,13 +4315,14 @@
           }
         },
         "level": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/level/-/level-4.0.0.tgz",
-          "integrity": "sha512-4epzCOlEcJ529NOdlAYiuiakS/kZTDdiKSBNJmE1B8bsmA+zEVwcpxyH86qJSQTpOu7SODrlaD9WgPRHLkGutA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/level/-/level-5.0.1.tgz",
+          "integrity": "sha512-wcak5OQeA4rURGacqS62R/xNHjCYnJSQDBOlm4KNUGJVE9bWv2B04TclqReYejN+oD65PzD4FsqeWoI5wNC5Lg==",
           "dev": true,
           "requires": {
-            "level-packager": "^3.0.0",
-            "leveldown": "^4.0.0",
+            "level-js": "^4.0.0",
+            "level-packager": "^5.0.0",
+            "leveldown": "^5.0.0",
             "opencollective-postinstall": "^2.0.0"
           }
         },
@@ -4304,6 +4330,12 @@
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
           "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==",
+          "dev": true
+        },
+        "level-concat-iterator": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+          "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
           "dev": true
         },
         "level-errors": {
@@ -4316,24 +4348,50 @@
           }
         },
         "level-iterator-stream": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
-          "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.1.tgz",
+          "integrity": "sha512-pSZWqXK6/yHQkZKCHrR59nKpU5iqorKM22C/BOHTb/cwNQ2EOZG+bovmFFGcOgaBoF3KxqJEI27YwewhJQTzsw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
-            "readable-stream": "^2.3.6",
+            "readable-stream": "^3.0.2",
             "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+              "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            }
+          }
+        },
+        "level-js": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/level-js/-/level-js-4.0.1.tgz",
+          "integrity": "sha512-m5JRIyHZn5VnCCFeRegJkn5bQd3MJK5qZX12zg3Oivc8+BUIS2yFS6ANMMeHX2ieGxucNvEn6/ZnyjmZQLLUWw==",
+          "dev": true,
+          "requires": {
+            "abstract-leveldown": "~6.0.1",
+            "immediate": "~3.2.3",
+            "inherits": "^2.0.3",
+            "ltgt": "^2.1.2",
+            "typedarray-to-buffer": "~3.1.5"
           }
         },
         "level-packager": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-3.1.0.tgz",
-          "integrity": "sha512-UxVEfK5WH0u0InR3WxTCSAroiorAGKzXWZT6i+nBjambmvINuXFUsFx2Ai3UIjUUtnyWhluv42jMlzUZCsAk9A==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.0.1.tgz",
+          "integrity": "sha512-tigB8g7xnFE5es2d/OmGJvcJC9S+FQfJnnULSLbPr53/ABPIaCarCxofkwdBhnJxjLZCNvj/Je6luFj/XeuaUQ==",
           "dev": true,
           "requires": {
-            "encoding-down": "~5.0.0",
-            "levelup": "^3.0.0"
+            "encoding-down": "^6.0.0",
+            "levelup": "^4.0.0"
           }
         },
         "level-post": {
@@ -4376,15 +4434,6 @@
                   "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
                   "dev": true
                 }
-              }
-            },
-            "bl": {
-              "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-              "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
-              "dev": true,
-              "requires": {
-                "readable-stream": "~1.0.26"
               }
             },
             "deferred-leveldown": {
@@ -4464,35 +4513,34 @@
           }
         },
         "leveldown": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-4.0.2.tgz",
-          "integrity": "sha512-SUgSRTWFh3eeiTdIt2a4Fi9TZO5oWzE9uC/Iw8+fVr1sk8x1S2l151UWwSmrMFZB3GxJhZIf4bQ0n+051Cctpw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.1.0.tgz",
+          "integrity": "sha512-+Ws1IDVSbJRJl/cP/JlapGSmt8xPSvZQpTlYGpyaMQiXtlx/fdMX30K2aHiTLxhLcnAg74D8odBG1Fk12/8SRA==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~5.0.0",
-            "bindings": "~1.3.0",
+            "abstract-leveldown": "~6.0.3",
             "fast-future": "~1.0.2",
-            "nan": "~2.12.1",
-            "prebuild-install": "~5.2.4"
+            "napi-macros": "~1.8.1",
+            "node-gyp-build": "~4.1.0"
           },
           "dependencies": {
-            "nan": {
-              "version": "2.12.1",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-              "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+            "node-gyp-build": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.0.tgz",
+              "integrity": "sha512-rGLv++nK20BG8gc0MzzcYe1Nl3p3mtwJ74Q2QD0HTEDKZ6NvOFSelY6s2QBPWIHRR8h7hpad0LiwajfClBJfNg==",
               "dev": true
             }
           }
         },
         "levelup": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
-          "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.0.1.tgz",
+          "integrity": "sha512-l7KXOkINXHgNqmz0v9bxvRnMCUG4gmShFrzFSZXXhcqFnfvKAW8NerVsTICpZtVhGOMAmhY6JsVoVh/tUPBmdg==",
           "dev": true,
           "requires": {
-            "deferred-leveldown": "~4.0.0",
+            "deferred-leveldown": "~5.0.0",
             "level-errors": "~2.0.0",
-            "level-iterator-stream": "~3.0.0",
+            "level-iterator-stream": "~4.0.0",
             "xtend": "~4.0.0"
           }
         },
@@ -4543,9 +4591,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "lodash.get": {
           "version": "4.4.2",
@@ -4584,9 +4632,9 @@
           "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
         },
         "lossy-store": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/lossy-store/-/lossy-store-1.2.3.tgz",
-          "integrity": "sha1-Vi4qkgPYZh9g6HEt5Af72t8nXck=",
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/lossy-store/-/lossy-store-1.2.4.tgz",
+          "integrity": "sha512-rvqTCHZxWLvHAJv2w5vdCr5xICAW/FiXQ9wZGaAfBlNGG2FuLX0URNcj/zXC3qr5zQ8lBCbW8EEmDCKi7Dsp1g==",
           "dev": true,
           "requires": {
             "mkdirp": "^0.5.1",
@@ -4707,12 +4755,6 @@
             "regex-cache": "^0.4.2"
           }
         },
-        "mimic-response": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true
-        },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -4737,9 +4779,9 @@
           }
         },
         "mixin-deep": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-          "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+          "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
           "dev": true,
           "requires": {
             "for-in": "^1.0.2",
@@ -4811,12 +4853,14 @@
           }
         },
         "multiblob-http": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/multiblob-http/-/multiblob-http-0.4.2.tgz",
-          "integrity": "sha512-hVaXryaqJ3vvKjRNcOCEadzgO99nR+haxlptswr3vRvgavbK/Y/I7/Nat12WIQno2/A8+nkbE+ZcrsN3UDbtQw==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multiblob-http/-/multiblob-http-1.0.0.tgz",
+          "integrity": "sha512-wKsVFCi3lSR75peYpFMRDbWeGm86qgYfBe9Otm8j73rs+a1OltSLcg8fsTCO+pJTbYyIV92Iw5lnVYYTs7zMvg==",
           "dev": true,
           "requires": {
+            "pull-many": "^1.0.8",
             "pull-stream": "^3.4.3",
+            "range-parser": "^1.2.0",
             "stream-to-pull-stream": "^1.7.0"
           }
         },
@@ -4827,9 +4871,9 @@
           "dev": true
         },
         "multiserver": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-3.3.2.tgz",
-          "integrity": "sha512-VR1VOH4lZiF8SwiAx/en8ShfOOiA7xtDu8HMawnKk0snmK0vn28/gFKnJGrYgBsoZHBzhB2mU6ZWb9VDGklN4A==",
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-3.3.6.tgz",
+          "integrity": "sha512-zuPjEaPEVMosWXnfNalXv3QyjYCwaD2emC6l/ozwMeaCcZ/Do7WMb/ZF8MC6TVwhV9Y7eTcnBiYEP/hq8zA2nA==",
           "dev": true,
           "requires": {
             "debug": "^4.1.1",
@@ -4862,16 +4906,25 @@
           }
         },
         "muxrpc": {
-          "version": "6.4.2",
-          "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.2.tgz",
-          "integrity": "sha512-1wRnouHgHO3JYN3xbyzQGTFsd/wo12/zaikmQusP8ma+lmL+ewNvuvuwKSEJasKQTRnbTwbzh/OPdt9N76CA4g==",
+          "version": "6.4.8",
+          "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.8.tgz",
+          "integrity": "sha512-9oLoLbiAWZAhgxQzquApj0eSfiTYPWLq4AV5mvCBjsicJKWOJlxAAxypHdlnmHeUbOxrPRweneHI7l+nzY/+aQ==",
           "dev": true,
           "requires": {
             "explain-error": "^1.0.1",
             "packet-stream": "~2.0.0",
             "packet-stream-codec": "^1.1.1",
             "pull-goodbye": "0.0.2",
-            "pull-stream": "^3.2.3"
+            "pull-stream": "^3.6.10"
+          }
+        },
+        "muxrpc-usage": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/muxrpc-usage/-/muxrpc-usage-2.1.0.tgz",
+          "integrity": "sha512-ZspYQd4n4pLy86Gu/yrEdHvg5NBrg4p2NayQ2NFelN1QyLZRLTKPlTyaa6DyztsCG7mjLzxFBw9jw9LReB8Azw==",
+          "dev": true,
+          "requires": {
+            "right-pad": "^1.0.1"
           }
         },
         "muxrpc-validation": {
@@ -4896,26 +4949,17 @@
           }
         },
         "muxrpcli": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/muxrpcli/-/muxrpcli-1.1.0.tgz",
-          "integrity": "sha1-Sum6mGq4JcSlwS/LccbaqB6rUVg=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/muxrpcli/-/muxrpcli-3.1.0.tgz",
+          "integrity": "sha512-GvnPFBTA5oHHJDI9U7cwiOWCbVOLHcuO8cprwRLPD/zEXBQWeZ5qOw3/wpT2GGFyXL/gCDm456EjYj7hjY7jiA==",
           "dev": true,
           "requires": {
+            "cont": "^1.0.3",
             "minimist": "^1.2.0",
-            "pull-stream": "^2.28.3",
-            "stream-to-pull-stream": "^1.6.6",
-            "word-wrap": "^1.1.0"
-          },
-          "dependencies": {
-            "pull-stream": {
-              "version": "2.28.4",
-              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
-              "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
-              "dev": true,
-              "requires": {
-                "pull-core": "~1.1.0"
-              }
-            }
+            "muxrpc-usage": "^2.0.1",
+            "pull-stream": "^3.6.9",
+            "stream-to-pull-stream": "^1.7.3",
+            "word-wrap": "^1.2.3"
           }
         },
         "mv": {
@@ -4941,9 +4985,9 @@
           }
         },
         "nan": {
-          "version": "2.13.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
           "optional": true
         },
         "nanomatch": {
@@ -4985,10 +5029,10 @@
             }
           }
         },
-        "napi-build-utils": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
-          "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA==",
+        "napi-macros": {
+          "version": "1.8.2",
+          "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-1.8.2.tgz",
+          "integrity": "sha512-Tr0DNY4RzTaBG2W2m3l7ZtFuJChTH6VZhXVhkGGjF/4cZTt+i8GcM9ozD+30Lmr4mDoZ5Xx34t2o4GJqYWDGcg==",
           "dev": true
         },
         "ncp": {
@@ -5009,25 +5053,21 @@
             "semver": "^5.4.1"
           }
         },
+        "neo-async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+          "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+        },
         "nice-try": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
           "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
           "dev": true
         },
-        "node-abi": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
-          "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
-          "dev": true,
-          "requires": {
-            "semver": "^5.4.1"
-          }
-        },
         "node-gyp-build": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.8.0.tgz",
-          "integrity": "sha512-bYbpIHyRqZ7sVWXxGpz8QIRug5JZc/hzZH4GbdT9HTZi6WmKCZ8GLvP8OZ9TTiIBvwPFKgtGrlWQSXDAvYdsPw==",
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+          "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
           "optional": true
         },
         "non-private-ip": {
@@ -5038,12 +5078,6 @@
           "requires": {
             "ip": "^1.1.5"
           }
-        },
-        "noop-logger": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-          "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-          "dev": true
         },
         "normalize-package-data": {
           "version": "2.5.0",
@@ -5066,9 +5100,9 @@
           }
         },
         "normalize-uri": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.1.1.tgz",
-          "integrity": "sha512-bui9/kzRGymbkxJsZEBZgDHK2WJWGOHzR0pCr404EpkpVFTkCOYaRwQTlehUE+7oI70mWNENncCWqUxT/icfHw==",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.1.2.tgz",
+          "integrity": "sha512-fHgUX0J9LLSfIQAX1jfn+E47Sh24eKm41flnEjLeMKL9VoW3z/QkOrlJqKbcnO5qWcKSH57o5nH+3V0NOXmvDw==",
           "dev": true
         },
         "npm-install-package": {
@@ -5085,18 +5119,6 @@
             "rc": "^1.1.0",
             "shellsubstitute": "^1.1.0",
             "untildify": "^2.1.0"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-          "dev": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -5158,14 +5180,6 @@
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
               "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
             },
-            "async": {
-              "version": "2.6.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-              "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-              "requires": {
-                "lodash": "^4.17.11"
-              }
-            },
             "balanced-match": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -5210,12 +5224,6 @@
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-            },
-            "commander": {
-              "version": "2.17.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-              "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-              "optional": true
             },
             "commondir": {
               "version": "1.0.1",
@@ -5377,24 +5385,6 @@
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
               "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
             },
-            "handlebars": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-              "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
-              "requires": {
-                "async": "^2.5.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                  "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-                }
-              }
-            },
             "has-flag": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5550,11 +5540,6 @@
                 "path-exists": "^3.0.0"
               }
             },
-            "lodash": {
-              "version": "4.17.11",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-              "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-            },
             "lodash.flattendeep": {
               "version": "4.4.0",
               "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -5623,11 +5608,6 @@
                 "brace-expansion": "^1.1.7"
               }
             },
-            "minimist": {
-              "version": "0.0.10",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-            },
             "mkdirp": {
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -5683,15 +5663,6 @@
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "requires": {
                 "wrappy": "1"
-              }
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-              "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
               }
             },
             "os-homedir": {
@@ -5990,24 +5961,6 @@
                 "require-main-filename": "^1.0.1"
               }
             },
-            "uglify-js": {
-              "version": "3.4.9",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-              "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-              "optional": true,
-              "requires": {
-                "commander": "~2.17.1",
-                "source-map": "~0.6.1"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                  "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                  "optional": true
-                }
-              }
-            },
             "uuid": {
               "version": "3.3.2",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -6034,11 +5987,6 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
               "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-            },
-            "wordwrap": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
             },
             "wrap-ansi": {
               "version": "2.1.0",
@@ -6274,6 +6222,22 @@
           "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
           "dev": true
         },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+            }
+          }
+        },
         "options": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
@@ -6340,9 +6304,9 @@
           }
         },
         "parse-entities": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.1.tgz",
-          "integrity": "sha512-NBWYLQm1KSoDKk7GAHyioLTvCZ5QjdH/ASBBQTD3iLiAWJXS5bg1jEWI8nIJ+vgVvsceBVBcDGRWSo0KVQBvvg==",
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
           "dev": true,
           "requires": {
             "character-entities": "^1.0.0",
@@ -6449,30 +6413,6 @@
           "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
           "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
           "dev": true
-        },
-        "prebuild-install": {
-          "version": "5.2.5",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.5.tgz",
-          "integrity": "sha512-6uZgMVg7yDfqlP5CPurVhtq3hUKBFNufiar4J5hZrlHTo59DDBEtyxw01xCdFss9j0Zb9+qzFVf/s4niayba3w==",
-          "dev": true,
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^2.0.3",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "napi-build-utils": "^1.0.1",
-            "node-abi": "^2.7.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.2.7",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
-          }
         },
         "preserve": {
           "version": "0.2.0",
@@ -6805,9 +6745,9 @@
           }
         },
         "pull-stream": {
-          "version": "3.6.9",
-          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
-          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+          "version": "3.6.11",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.11.tgz",
+          "integrity": "sha512-43brwtqO0OSltctKbW1mgzzKH4TNE8egkW+Y4BFzlDWiG2Ayl7VKr4SeuoKacfgPfUWcSwcPlHsf40BEqNR32A=="
         },
         "pull-through": {
           "version": "1.0.18",
@@ -6883,16 +6823,6 @@
             "ws": "^1.1.0"
           }
         },
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
         "push-stream": {
           "version": "10.0.4",
           "resolved": "https://registry.npmjs.org/push-stream/-/push-stream-10.0.4.tgz",
@@ -6952,6 +6882,12 @@
               "dev": true
             }
           }
+        },
+        "range-parser": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+          "dev": true
         },
         "rc": {
           "version": "1.2.8",
@@ -7433,9 +7369,9 @@
           }
         },
         "resolve": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
           "requires": {
             "path-parse": "^1.0.6"
           }
@@ -7470,6 +7406,12 @@
           "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
         },
+        "right-pad": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
+          "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
+          "dev": true
+        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -7480,9 +7422,9 @@
           },
           "dependencies": {
             "glob": {
-              "version": "7.1.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+              "version": "7.1.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+              "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
               "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -7505,6 +7447,12 @@
           "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.8.tgz",
           "integrity": "sha512-+GztYEPRpIsQoCSraWHDBs9WVy4eVME16zhOtDB4H9J4xN0XRhknnmLOl+4gRgZtu8dpp9N/utSPjKH/xmDzXg=="
         },
+        "rwlock": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/rwlock/-/rwlock-5.0.0.tgz",
+          "integrity": "sha1-iI1qd6M1HMGiCSBO8u4XIgk4Ns8=",
+          "dev": true
+        },
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -7520,13 +7468,12 @@
           }
         },
         "secret-handshake": {
-          "version": "1.1.16",
-          "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.16.tgz",
-          "integrity": "sha512-iJgGEykTXa8772vmYMGM20jYifTV7lg96bFeitGjly99aIEkIKHkiJWb+3KZ98dg4gwtF/6L+XhL/76iBgKhpA==",
+          "version": "1.1.18",
+          "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.18.tgz",
+          "integrity": "sha512-uP8s0ALmbJtjLEShGnJ5HHJSM1+TT8hbUme2/H2grw+WbiofSG6kr6AK1HHOmSublCVNFwfggjnWZXnEPTvIwQ==",
           "dev": true,
           "requires": {
-            "chloride": "^2.2.7",
-            "deep-equal": "~1.0.0",
+            "chloride": "^2.2.8",
             "explain-error": "^1.0.4",
             "pull-box-stream": "^1.0.13",
             "pull-handshake": "^1.1.1",
@@ -7534,9 +7481,9 @@
           }
         },
         "secret-stack": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-6.1.0.tgz",
-          "integrity": "sha512-p25ZAtozHeQEcFSNdxGgtkTkzoEwdq2c1Z0NXoTrLdvaAd+Oxu51oZ/iITKzz7rji5amutnicIzeb6zlij8czA==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-6.3.1.tgz",
+          "integrity": "sha512-SyYRGgjxq8lbQyqdIbaNfteZ77B3Bd2TH+k5WpI6gHjTCOKZZmD8aiat+bUfhjsiqf0LMQauRH3KD6vIMdDPLg==",
           "dev": true,
           "requires": {
             "debug": "^4.1.0",
@@ -7544,7 +7491,7 @@
             "ip": "^1.1.5",
             "map-merge": "^1.1.0",
             "multiserver": "^3.1.0",
-            "muxrpc": "^6.4.0",
+            "muxrpc": "^6.4.8",
             "non-private-ip": "^1.4.3",
             "pull-inactivity": "~2.1.1",
             "pull-rate": "^1.0.2",
@@ -7564,16 +7511,10 @@
           "integrity": "sha1-5DNnaTICBFTjwUhwxRfqHeVsL6Q=",
           "dev": true
         },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "dev": true
-        },
         "set-value": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-          "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+          "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -7626,23 +7567,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
-        "simple-concat": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-          "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-          "dev": true
-        },
-        "simple-get": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-          "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-          "dev": true,
-          "requires": {
-            "decompress-response": "^3.3.0",
-            "once": "^1.3.1",
-            "simple-concat": "^1.0.0"
-          }
         },
         "smart-buffer": {
           "version": "4.0.2",
@@ -7795,9 +7719,9 @@
           }
         },
         "sodium-browserify-tweetnacl": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.5.tgz",
-          "integrity": "sha512-Q6YgyMyEB7dFLTt3vB8/YSjmSQrpQ/J4VEZfivOxRXFRs8BLjn39jA2X7sJO1Co4+Ma5kD+DSZm8x7Tum7ajQw==",
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.6.tgz",
+          "integrity": "sha512-ZnEI26hdluilpYY28Xc4rc1ALfmEp2TWihkJX6Mdtw0z9RfHfpZJU7P8DoKbN1HcBdU9aJmguFZs7igE8nLJPg==",
           "requires": {
             "chloride-test": "^1.1.0",
             "ed2curve": "^0.1.4",
@@ -7828,9 +7752,9 @@
           "integrity": "sha512-8AVzr9VHueXqfzfkzUA0aXe/Q4XG3UTmhlP6Pt+HQc5bbAPIJFo7ZIMh9tvn+99QuiMcyDJdYumegGAczl0N+g=="
         },
         "sodium-native": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.3.0.tgz",
-          "integrity": "sha512-TYId1m2iLXXot2Q3KA6u8Ti9pmL24T2cm8nb9OUGFFmTxdw4I+vnkjcPVA4LT1acw+A86iJkEn+8iV51jcTWUg==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.2.tgz",
+          "integrity": "sha512-qwHcUnzFpRSGSm6F49j/h5SnxPFBgSNdDwZkAqjvuAoHQIVBFOXYb+oCUTJV80K5hRqSYCihpbX06vbrtPbilg==",
           "optional": true,
           "requires": {
             "ini": "^1.3.5",
@@ -7906,14 +7830,14 @@
           }
         },
         "ssb-blobs": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.1.14.tgz",
-          "integrity": "sha512-xDRcpBcfafylwsLuTeFM+QaYl8mjc19u3UsrpIQckRkHd4c300zXUKS8NyOmZGiGDWVObCMV1WGI+e0AlYrDLw==",
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.2.2.tgz",
+          "integrity": "sha512-N+X46lE/KaIH9y1w3LQ9pPnt2tQr5VCSj1dAo/pJGYnSwnHz8GhIiboq7UGzrCZwCWgVUs22/2YiytCXSC9ASg==",
           "dev": true,
           "requires": {
             "cont": "^1.0.3",
             "debug": "^4.1.1",
-            "level": "^4.0.0",
+            "level": "^5.0.1",
             "multiblob": "^1.12.0",
             "pull-level": "^2.0.4",
             "pull-notify": "^0.1.0",
@@ -7921,40 +7845,32 @@
             "ssb-ref": "^2.3.0"
           }
         },
+        "ssb-caps": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/ssb-caps/-/ssb-caps-1.0.1.tgz",
+          "integrity": "sha512-ULJhokqDW4a9l7xXKPHwbhLQgRZmEjwdrrXMsPGoVYnvKb9sJuJ8ki9ilBZIs+NmYuAV+H1ffbB2Z4uioBtFYQ==",
+          "dev": true
+        },
         "ssb-client": {
-          "version": "4.7.2",
-          "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.7.2.tgz",
-          "integrity": "sha512-sZPs/i5Zm8f3faJDbYYpBlxocIYi8VR4KksQrHbncYCnCo1n4diBmLx76dNRC3p0rpyqgkX38gMcEVIYe4dYZw==",
+          "version": "4.7.9",
+          "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.7.9.tgz",
+          "integrity": "sha512-koVuazgGa+Pz7KHnPTsOFvaKSrE0T38wSO7n6P7ZQp+1BpaoBCI4z8Kq2SvMw521Sz9dK9Rwh2bTakEDRgx84A==",
           "dev": true,
           "requires": {
             "explain-error": "^1.0.1",
             "multicb": "^1.2.1",
             "multiserver": "^3.1.2",
-            "muxrpc": "^6.4.0",
+            "muxrpc": "^6.4.8",
             "pull-hash": "^1.0.0",
             "pull-stream": "^3.6.0",
-            "ssb-config": "^2.3.9",
+            "ssb-config": "^3.2.5",
             "ssb-keys": "^7.0.13"
-          },
-          "dependencies": {
-            "ssb-config": {
-              "version": "2.3.9",
-              "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-2.3.9.tgz",
-              "integrity": "sha512-UF+4+khFXILLBqtu9HfrpUwYnDXIdAyJe3u9X4GrApuoakxuSKwaUGakUxLPyo6COyV2brMqufUgf+fDOI8Ftw==",
-              "dev": true,
-              "requires": {
-                "deep-extend": "^0.6.0",
-                "non-private-ip": "^1.2.1",
-                "os-homedir": "^1.0.1",
-                "rc": "^1.1.6"
-              }
-            }
           }
         },
         "ssb-config": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.2.5.tgz",
-          "integrity": "sha512-mnrZFOzWWkF6QWzJUirE1mH3v3XyfsZxzEq3TeAJ03vqawSXl1zi1+rxjFHAgmvTXTEw2tROxzzXRCO+tE8u+w==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.3.0.tgz",
+          "integrity": "sha512-YJ2WvsfXPsGzyVnnYYs85mUJ67I8G9ZTGwkB95RNSboNSFfp+zNulze5QXTYq/KKQTAgV1h4pvJLIQvBr7MwUQ==",
           "dev": true,
           "requires": {
             "deep-extend": "^0.6.0",
@@ -7966,9 +7882,9 @@
           }
         },
         "ssb-db": {
-          "version": "19.1.1",
-          "resolved": "https://registry.npmjs.org/ssb-db/-/ssb-db-19.1.1.tgz",
-          "integrity": "sha512-8UxgKZGmsmBs8LWA5N7mPBSttvIclMT1jbcssP0m/8CD+NvIin+VygiKfdLTRLG5knNraTGt9o9a3Dil+eqbhA==",
+          "version": "19.2.0",
+          "resolved": "https://registry.npmjs.org/ssb-db/-/ssb-db-19.2.0.tgz",
+          "integrity": "sha512-pJAFizB6OcuJLX4RJJuU9HWyPwM2CqLi/vs08lhVIR3TGxacxpavvK5LzbxT+Y3iWkBchOTKS5hHCigA5aaung==",
           "dev": true,
           "requires": {
             "async-write": "^2.1.0",
@@ -7998,9 +7914,9 @@
           }
         },
         "ssb-ebt": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.6.1.tgz",
-          "integrity": "sha512-dYiVsDH2ywdY3IhQPKkm8r/gbMyVREvLJ/sExW+vrgOOFJgvC5MZe+1xXzhtudjlB2SyF3zxj02mjaT1FWm6ug==",
+          "version": "5.6.4",
+          "resolved": "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.6.4.tgz",
+          "integrity": "sha512-ZNqOECzKyFBJW15N8Fl4iY7MGvb1ZTBxBVjcrQy7NydJn8sbHpC7PUU3QnnNgECwzoEWkuxzkn04GHJHJypo3g==",
           "dev": true,
           "requires": {
             "base64-url": "^2.2.0",
@@ -8024,9 +7940,9 @@
           }
         },
         "ssb-friends": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-4.0.0.tgz",
-          "integrity": "sha512-47Y0QQQSOVpRzs+kRkhmpXawYBljvGPzGXL/bo+tn7dxbM6BW0BIy7UMGHpzHO/JK9z9CdaxnMNu0DpRUJ3tOw==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-4.1.0.tgz",
+          "integrity": "sha512-Ltvlf0i+9KvVr1xjbRykrl1Ngu7lAvjuKe2vki6KYOTkQOWpSVh/weKT817J4S5ere36tLufq5HfXf5c/LGFuQ==",
           "dev": true,
           "requires": {
             "flumeview-reduce": "^1.3.0",
@@ -8048,9 +7964,9 @@
           }
         },
         "ssb-gossip": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/ssb-gossip/-/ssb-gossip-1.0.9.tgz",
-          "integrity": "sha512-IEvAjr3g37/J6oQtBGB0ivCO6mWrWQZebs73VPXG1wecxccigCwtDSSAIit7A9cpm3d0p59SwtibbfoBFcPJVA==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ssb-gossip/-/ssb-gossip-1.1.0.tgz",
+          "integrity": "sha512-z4DBUtGJ+/k6z67EjavmPYAKz9BLF7zWcSDwUwLKZZT3AJp/5J6iPxHkilz2UfJ9LdGT4gF5CUe2xyIt1QFguA==",
           "dev": true,
           "requires": {
             "atomic-file": "^1.1.5",
@@ -8069,27 +7985,27 @@
           }
         },
         "ssb-invite": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/ssb-invite/-/ssb-invite-2.0.4.tgz",
-          "integrity": "sha512-G90s2b5k80WTt2NfuEXZwVxY3Ik8qFFcIz8wUM5F7pBjdyqGgmksJccLJoKnjMYr7SEPTu3Blzl1EWdzqao8AA==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ssb-invite/-/ssb-invite-2.1.3.tgz",
+          "integrity": "sha512-hHLsmlTqk6ecxpWlHiwpFNwXDfMY8gO6OdXrU2lkoqLStPrriPgzlCJnfZA06Gdi2ZL5Az4+M2fyWvnza9x/kg==",
           "dev": true,
           "requires": {
             "cont": "^1.0.3",
             "explain-error": "^1.0.4",
             "ip": "^1.1.5",
-            "level": "^4.0.0",
+            "level": "^5.0.0",
             "level-sublevel": "^6.6.5",
             "mdmanifest": "^1.0.8",
             "muxrpc-validation": "^3.0.0",
-            "ssb-client": "^4.6.0",
+            "ssb-client": "^4.7.4",
             "ssb-keys": "^7.1.3",
             "ssb-ref": "^2.13.9"
           }
         },
         "ssb-keys": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.1.5.tgz",
-          "integrity": "sha512-GQ7cgTFROOrQpHjmZdeIrVO15+KImjTCCdM4IaJCAMgEybaXl53wEi2guPqYAskqBggWxYG0VNwXT45JI9nXiA==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.1.6.tgz",
+          "integrity": "sha512-DCl6BTz7zy7fElWgok1aBvYBfe6aUzafW1Q7z5WkpgdT8H90oqXe2l5DyTd7k77yyg82uDSjPOKfPAE9eBqfug==",
           "requires": {
             "chloride": "^2.2.8",
             "mkdirp": "~0.5.0",
@@ -8097,9 +8013,9 @@
           }
         },
         "ssb-links": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/ssb-links/-/ssb-links-3.0.4.tgz",
-          "integrity": "sha512-npTjUeg+qH8NgnZqKsRSe5kLCu2KYQs9vxtckBph8Z5/VJX+RAG5a5FlLEOLWv4h//BICe4L7Rpvbxol+39jhQ==",
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/ssb-links/-/ssb-links-3.0.6.tgz",
+          "integrity": "sha512-X+Hhj9E1PoGS5fQMBsUMgbULLI+e93kQTrygKs9EL9nUeIOOpMelQ1XDdBUIgP40qHK8esAVVES6dWmba15TfA==",
           "dev": true,
           "requires": {
             "flumeview-query": "^6.0.0",
@@ -8107,6 +8023,31 @@
             "pull-stream": "^3.1.0",
             "ssb-msgs": "^5.2.0"
           }
+        },
+        "ssb-local": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ssb-local/-/ssb-local-1.0.0.tgz",
+          "integrity": "sha512-aIkz+tDsAQFLbcN5d9itipHG71EG62UdIwojz78BQBxD7kGTwMezZofkMplURp9/njwdqMiqxYEUMvOh8Emh/w==",
+          "dev": true,
+          "requires": {
+            "broadcast-stream": "^0.2.2",
+            "ssb-ref": "^2.13.9"
+          }
+        },
+        "ssb-logging": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ssb-logging/-/ssb-logging-1.0.0.tgz",
+          "integrity": "sha512-6apTG47+VgLAD3MYkpRTbO27DMDh0YLJIvWfcJUEo5FdrjnLsqDl1kkzQ4B5MbH08z5Vklx5907t4by9rhlROQ==",
+          "dev": true,
+          "requires": {
+            "bash-color": "0.0.4"
+          }
+        },
+        "ssb-master": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ssb-master/-/ssb-master-1.0.2.tgz",
+          "integrity": "sha512-Sn19i0OrQYRqC8MEN7NLO8oX+/qE3fZ6VDuw6iUC7S9VIe8oh2A9bWKTGL8GR1vG5+HyxVSRo8FdgcglJDBc3g==",
+          "dev": true
         },
         "ssb-msgs": {
           "version": "5.2.0",
@@ -8117,10 +8058,28 @@
             "ssb-ref": "^2.0.0"
           }
         },
+        "ssb-no-auth": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ssb-no-auth/-/ssb-no-auth-1.0.0.tgz",
+          "integrity": "sha512-+o9WnY566shLyiJp6l21+SHZfgv40SEr35PtoF3uuFYI24vFhgcfv77pXvWpDINVyX2uQ152o2eQHg1amlp6lQ==",
+          "dev": true,
+          "requires": {
+            "multiserver": "^3.3.3"
+          }
+        },
+        "ssb-onion": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ssb-onion/-/ssb-onion-1.0.0.tgz",
+          "integrity": "sha512-iRXjeI0sbRbgMwaKg+poqhHSH7GvUVgJ+8ysi8q7Hjj4wHkczLGAOyVjnyhjF+ErPDFn9kXN+46joneKqSgEDg==",
+          "dev": true,
+          "requires": {
+            "multiserver": "^3.3.3"
+          }
+        },
         "ssb-ooo": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/ssb-ooo/-/ssb-ooo-1.2.2.tgz",
-          "integrity": "sha512-KoBHpU7ytEXGJTD59CpTMCW7IpMtRbunYzu6i8nDpocvOfmJjqHS22q8FiseNU1xeTEPmv2uOevMrOxwNL2/yQ==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/ssb-ooo/-/ssb-ooo-1.3.0.tgz",
+          "integrity": "sha512-xiXe+RHomaf/XAlzJm0/z8pNZeQ9bSZNAlxUgNd6loXvkCzCt1mTJptMUe+CHeHiPuLgkwFa6pN1SWIhlVd7Hg==",
           "dev": true,
           "requires": {
             "flumecodec": "0.0.1",
@@ -8151,10 +8110,31 @@
             }
           }
         },
+        "ssb-plugins": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ssb-plugins/-/ssb-plugins-1.0.0.tgz",
+          "integrity": "sha512-eM8vid+K8MhwZwzk/CDUhSNhUoS6wYgq9clJrrKaP0/Otdd3zZzcBQw54Xvm0olMcOgpTSlY3m2rT4iqjZPIBw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.5",
+            "explain-error": "^1.0.4",
+            "mdmanifest": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "muxrpc": "^6.4.0",
+            "muxrpc-validation": "^3.0.0",
+            "mv": "^2.1.1",
+            "osenv": "^0.1.5",
+            "pull-cat": "^1.1.11",
+            "pull-many": "^1.0.8",
+            "pull-pushable": "^2.2.0",
+            "pull-stream": "^3.6.9",
+            "stream-to-pull-stream": "^1.7.2"
+          }
+        },
         "ssb-query": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-2.3.0.tgz",
-          "integrity": "sha512-y4OA2MvGl1jU7bUTYsTmMNSqlPt4eh9401THUW1DO4aFyBFEWvpa3eKJHc8aTmaph2hutPPbdKgEFsWDzw26uw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-2.4.1.tgz",
+          "integrity": "sha512-n/WsKn2xvLp2PidaNgInGji1t6te959p1dNBdZ69rhTVOD9oR+YQ4M3z20d70F6XsUgbyFlVMSvvkfRcubVTkg==",
           "dev": true,
           "requires": {
             "explain-error": "^1.0.1",
@@ -8205,13 +8185,12 @@
           }
         },
         "ssb-replicate": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/ssb-replicate/-/ssb-replicate-1.2.3.tgz",
-          "integrity": "sha512-9/z5Jsnm9PegLWSZWOTWDBl3rmNNHk3+7EWtlsORJv7sSVmVCLYyHO2w98il+WO/xFGOd2khf+LO+VjzM8JJJw==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/ssb-replicate/-/ssb-replicate-1.3.0.tgz",
+          "integrity": "sha512-FLizJ+eHtGrySb61v3asIKpZkje77a6Cl7ZotUjD3YjNUOC7y+HN0AWaupbiiFiQXDGrIZ0ti0Mr8bHkMOJurQ==",
           "dev": true,
           "requires": {
             "deep-equal": "^1.0.1",
-            "mdmanifest": "^1.0.8",
             "observ-debounce": "^1.1.1",
             "obv": "0.0.1",
             "pull-cat": "^1.1.11",
@@ -8221,6 +8200,15 @@
             "pull-pushable": "^2.2.0",
             "pull-stream": "^3.6.9",
             "ssb-ref": "^2.13.9"
+          }
+        },
+        "ssb-unix-socket": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ssb-unix-socket/-/ssb-unix-socket-1.0.0.tgz",
+          "integrity": "sha512-Z4jBj917W+dKAiDglwxCpWm8vINOMtkpHQIgk50NQTb5jHqHI5Rcyiy7EO0uRcWwRWqXi1ZwOTEFVyLyyuittA==",
+          "dev": true,
+          "requires": {
+            "multiserver": "^3.3.3"
           }
         },
         "ssb-validate": {
@@ -8235,17 +8223,16 @@
           }
         },
         "ssb-ws": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/ssb-ws/-/ssb-ws-5.1.1.tgz",
-          "integrity": "sha512-Wbttwlr+wVqcoxGsn+WoiBbSI9UMqgL/DZU6Pjm/KQ61LO7jaxV4hGw3+H4uRBtgtOE4pidvHeCk7jUuoXWZfQ==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ssb-ws/-/ssb-ws-6.2.1.tgz",
+          "integrity": "sha512-PR8vJVhLo8eIWfPa/NRpVWRSmASDQFS/KxHsfBmz1zGrMnLNGSW28KD5A/jVsFLDQfDlNyC75dThgUbEIki4mQ==",
           "dev": true,
           "requires": {
             "emoji-server": "^1.0.0",
-            "multiblob-http": "^0.4.2",
+            "multiblob-http": "^1.0.0",
             "multiserver": "^3.0.2",
-            "multiserver-scopes": "^1.0.0",
-            "muxrpc": "^6.3.3",
             "pull-box-stream": "^1.0.13",
+            "pull-stream": "^3.6.9",
             "ssb-ref": "^2.3.0",
             "stack": "^0.1.0"
           }
@@ -8397,9 +8384,9 @@
           },
           "dependencies": {
             "glob": {
-              "version": "7.1.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+              "version": "7.1.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+              "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
               "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -8412,45 +8399,6 @@
             }
           }
         },
-        "tar-fs": {
-          "version": "1.16.3",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-          "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
-          "dev": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pump": "^1.0.0",
-            "tar-stream": "^1.1.2"
-          },
-          "dependencies": {
-            "pump": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-              "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-              "dev": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            }
-          }
-        },
-        "tar-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-          "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-          "dev": true,
-          "requires": {
-            "bl": "^1.0.0",
-            "buffer-alloc": "^1.2.0",
-            "end-of-stream": "^1.0.0",
-            "fs-constants": "^1.0.0",
-            "readable-stream": "^2.3.0",
-            "to-buffer": "^1.1.1",
-            "xtend": "^4.0.0"
-          }
-        },
         "text-table": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8461,12 +8409,6 @@
           "version": "2.3.8",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        },
-        "to-buffer": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-          "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
           "dev": true
         },
         "to-camel-case": {
@@ -8556,9 +8498,9 @@
           "dev": true
         },
         "trim-lines": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.1.tgz",
-          "integrity": "sha512-X+eloHbgJGxczUk1WSjIvn7aC9oN3jVE3rQfRVKcgpavi3jxtCn0VVKtjOBj64Yop96UYn/ujJRpTbCdAF1vyg==",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.2.tgz",
+          "integrity": "sha512-3GOuyNeTqk3FAqc3jOJtw7FTjYl94XBR5aD9QnDbK/T4CA9sW/J0l9RoaRPE9wyPP7NF331qnHnvJFBJ+IDkmQ==",
           "dev": true
         },
         "trim-newlines": {
@@ -8572,19 +8514,10 @@
           "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
         },
         "trim-trailing-lines": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
-          "integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg==",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+          "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
           "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -8604,6 +8537,15 @@
           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
           "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
           "dev": true
+        },
+        "typedarray-to-buffer": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+          "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+          "dev": true,
+          "requires": {
+            "is-typedarray": "^1.0.0"
+          }
         },
         "typewise": {
           "version": "1.0.3",
@@ -8626,10 +8568,28 @@
           "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4=",
           "dev": true
         },
+        "uglify-js": {
+          "version": "3.5.14",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.14.tgz",
+          "integrity": "sha512-dgyjIw8KFK6AyVl5vm2tEqPewv5TKGEiiVFLI1LbF+oHua/Njd8tZk3lIbF1AWU1rNdEg7scaceADb4zqCcWXg==",
+          "optional": true,
+          "requires": {
+            "commander": "~2.20.0",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "optional": true
+            }
+          }
+        },
         "uint48be": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/uint48be/-/uint48be-1.0.2.tgz",
-          "integrity": "sha512-jNn1eEi81BLiZfJkjbiAKPDMj7iFrturKazqpBu0aJYLr6evgkn+9rgkX/gUwPBj5j2Ri5oUelsqC/S1zmpWBA==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uint48be/-/uint48be-2.0.1.tgz",
+          "integrity": "sha512-LQvWofTo3RCz+XaQR3VNch+dDFwpIvWr/98imhQne++vFhpQP16YAC/a8w9N00Heqqra00ACjHT18cgvn5H+bg==",
           "dev": true
         },
         "ultron": {
@@ -8639,9 +8599,9 @@
           "dev": true
         },
         "unherit": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
-          "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+          "integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -8663,38 +8623,15 @@
           }
         },
         "union-value": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+          "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
             "get-value": "^2.0.6",
             "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "set-value": {
-              "version": "0.4.3",
-              "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-              "dev": true,
-              "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.1",
-                "to-object-path": "^0.3.0"
-              }
-            }
+            "set-value": "^2.0.1"
           }
         },
         "unique-random": {
@@ -8726,9 +8663,9 @@
           }
         },
         "unist-util-visit-parents": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
-          "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.0.tgz",
+          "integrity": "sha512-j0XZY3063E6v7qhx4+Q2Z0r8SMrLX7Mr6DabiCy67zMEcFQYtpNOplLlEK1KKEBEs9S+xB5U+yloQxbSwF9P/g==",
           "dev": true,
           "requires": {
             "unist-util-is": "^2.1.2"
@@ -8888,26 +8825,16 @@
             "isexe": "^2.0.0"
           }
         },
-        "which-pm-runs": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-          "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-          "dev": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
         "word-wrap": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
           "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
           "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         },
         "wrap-fn": {
           "version": "0.1.5",
@@ -8964,9 +8891,9 @@
       }
     },
     "ssb-ws": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ssb-ws/-/ssb-ws-6.2.0.tgz",
-      "integrity": "sha512-XUCdrrwugsR00hlKMrgFTtuMtE8jKpbfpvvry2481ItRYdyFDdPpuYFPk+8lMJUiCjtypkJGLPfd+/VszAA28Q==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ssb-ws/-/ssb-ws-6.2.3.tgz",
+      "integrity": "sha512-zZ/Q1M+9ZWlrchgh4QauD/MEUFa6eC6H6FYq6T8Of/y82JqsQBLwN6YlzbO09evE7Rx6x0oliXDCnQSjwGwQRA==",
       "dev": true,
       "requires": {
         "emoji-server": "^1.0.0",
@@ -9001,22 +8928,49 @@
       }
     },
     "string.prototype.trim": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
+      "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        }
       }
     },
     "strip-json-comments": {
@@ -9025,39 +8979,47 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "tape": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.10.1.tgz",
-      "integrity": "sha512-G0DywYV1jQeY3axeYnXUOt6ktnxS9OPJh97FGR3nrua8lhWi1zPflLxcAHavZ7Jf3qUfY7cxcVIVFa4mY2IY1w==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.0.tgz",
+      "integrity": "sha512-J/hvA+GJnuWJ0Sj8Z0dmu3JgMNU+MmusvkCT7+SN4/2TklW18FNCp/UuHIEhPZwHfy4sXfKYgC7kypKg4umbOw==",
       "dev": true,
       "requires": {
-        "deep-equal": "~1.0.1",
+        "deep-equal": "~1.1.1",
         "defined": "~1.0.0",
+        "dotignore": "~0.1.2",
         "for-each": "~0.3.3",
         "function-bind": "~1.1.1",
-        "glob": "~7.1.3",
+        "glob": "~7.1.6",
         "has": "~1.0.3",
-        "inherits": "~2.0.3",
+        "inherits": "~2.0.4",
+        "is-regex": "~1.0.5",
         "minimist": "~1.2.0",
-        "object-inspect": "~1.6.0",
-        "resolve": "~1.10.0",
+        "object-inspect": "~1.7.0",
+        "resolve": "~1.14.2",
         "resumer": "~0.0.0",
-        "string.prototype.trim": "~1.1.2",
+        "string.prototype.trim": "~1.2.1",
         "through": "~2.3.8"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+        "deep-equal": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "is-arguments": "^1.0.4",
+            "is-date-object": "^1.0.1",
+            "is-regex": "^1.0.4",
+            "object-is": "^1.0.1",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.2.0"
           }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
         }
       }
     },
@@ -9078,14 +9040,6 @@
       "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
       "requires": {
         "tweetnacl": "0.x.x"
-      }
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
       }
     },
     "typewise": {

--- a/package.json
+++ b/package.json
@@ -11,20 +11,20 @@
     "cont": "^1.0.3",
     "explain-error": "^1.0.4",
     "ip": "^1.1.5",
-    "level": "^5.0.0",
+    "level": "^6.0.0",
     "level-sublevel": "^6.6.5",
-    "muxrpc-validation": "^3.0.0",
-    "ssb-client": "^4.7.4",
-    "ssb-keys": "^7.1.3",
+    "muxrpc-validation": "^3.0.2",
+    "ssb-client": "^4.9.0",
+    "ssb-keys": "^7.2.2",
     "ssb-ref": "^2.13.9"
   },
   "devDependencies": {
-    "pull-stream": "^3.6.11",
-    "ssb-friends": "^4.1.0",
-    "ssb-replicate": "^1.0.1",
-    "ssb-server": "^14.1.0",
-    "ssb-ws": "^6.2.0",
-    "tape": "^4.9.2"
+    "pull-stream": "^3.6.14",
+    "ssb-friends": "^4.1.4",
+    "ssb-replicate": "^1.3.2",
+    "ssb-server": "^15.0.0",
+    "ssb-ws": "^6.2.3",
+    "tape": "^4.13.0"
   },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"


### PR DESCRIPTION
Problem: Our npm dependencies are outdated and I'd like to have Level 6.

Solution: Upgrade all of the packages and run `npm update`.