### PR TITLE
support ssb-friends@5 as a breaking change

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,11 +148,9 @@ module.exports = {
           if (err) return cb(err)
 
           // check if we're already following them
-          server.friends.get((err, follows) => {
+          server.friends.isFollowing({ source: server.id, dest: req.feed }, (err, isFollowing) => {
             if (err) return cb(err)
-            //          server.friends.all('follow', function(err, follows) {
-            //            if(hops[req.feed] == 1)
-            if (follows && follows[server.id] && follows[server.id][req.feed]) { return cb(new Error('already following')) }
+            if (isFollowing) { return cb(new Error('already following')) }
 
             // although we already know the current feed
             // it's included so that request cannot be replayed.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "pull-stream": "^3.6.14",
     "scuttle-testbot": "^1.2.3",
-    "ssb-friends": "^4.1.4",
+    "ssb-friends": "^5.1.0",
     "ssb-replicate": "^1.3.2",
     "ssb-ws": "^6.2.3",
     "standard": "^14.3.4",


### PR DESCRIPTION
ssb-friends@5 doesn't have `get()`, it has `isFollowing`. This would be a breaking change, so I would make a major version bump.

Depends on #27 merged first.