### PR TITLE
Double invite use

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,16 +244,22 @@ module.exports = {
 
           // command the peer to follow me
           rpc.invite.use({ feed: server.id }, (err, msg) => {
-            if (err) return cb(explain(err, 'invite not accepted'))
+            if (err && err.message !== 'already following') {
+              return cb(explain(err, 'invite not accepted'))
+            }
 
-            // follow and announce the pub
+            // (maybe) follow and announce the pub
             cont.para([
-              cont(server.publish)({
-                type: 'contact',
-                following: true,
-                autofollow: true,
-                contact: opts.key
-              }),
+              (
+                (err && err.message === 'already following')
+                  ? (cb) => cb()
+                  : cont(server.publish)({
+                    type: 'contact',
+                    following: true,
+                    autofollow: true,
+                    contact: opts.key
+                  })
+              ),
               (
                 opts.host
                   ? cont(server.publish)({

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -106,39 +106,52 @@ tape('test invite.accept doesnt follow if already followed', function (t) {
         if (err) throw err
         // console.log(hops)
         t.equal(hops[bob.id], 1)
-        all(bob.messagesByType('pub'), function (err, ary) {
-          if (err) throw err
-          t.equal(ary.length, 1)
 
-          // it's rare, but some times, someone's home computer has a public address.
-          // this makes the tests fail unless we get the address the same way as invite code.
-          var expected = alice.address('public') || alice.address('local') || alice.address('device')
-
-          t.deepEqual({
-            type: 'pub',
-            address: ref.parseAddress(expected.split(';').shift())
-          }, ary[0].value.content)
-
-          all(bob.messagesByType('contact'), function (err, ary) {
+        bob.invite.accept(invite, (err) => {
+          t.error(err, 'no error')
+          all(bob.messagesByType('pub'), function (err, ary) {
             if (err) throw err
 
-            // console.log(ary)
-            t.equal(ary.length, 1)
+            // it's rare, but some times, someone's home computer has a public address.
+            // this makes the tests fail unless we get the address the same way as invite code.
+            var expected = alice.address('public') || alice.address('local') || alice.address('device')
+            t.deepEqual(
+              ary.map(m => m.value.content),
+              [
+                {
+                  type: 'pub',
+                  address: ref.parseAddress(expected.split(';').shift())
+                },
+                {
+                  type: 'pub',
+                  address: ref.parseAddress(expected.split(';').shift())
+                }
+              ],
+              'two pub announce'
+              // NOTE this is an undesired side effect (two identical pub announce messages)
+              // but meh
+            )
 
-            t.deepEqual({
-              type: 'contact',
-              contact: alice.id,
-              autofollow: true,
-              following: true
-            }, ary[0].value.content)
+            all(bob.messagesByType('contact'), function (err, ary) {
+              if (err) throw err
 
-            bob.invite.accept(invite, (err) => {
-              t.match(err.message, /invite not accepted/, 'wont use an invite for a person who is already followed')
+              t.deepEqual(
+                ary.map(m => m.value.content),
+                [{
+                  type: 'contact',
+                  contact: alice.id,
+                  autofollow: true,
+                  following: true
+                }],
+                'only one follow'
+              )
+
               alice.friends.hops(alice.id, (err, hops) => {
                 if (err) throw err
 
                 // console.log(hops)
-                t.equal(hops[bob.id], 1)
+                t.equal(hops[bob.id], 1, 'correct hops')
+
                 alice.close(true)
                 bob.close(true)
                 t.end()
@@ -150,6 +163,65 @@ tape('test invite.accept doesnt follow if already followed', function (t) {
     })
   })
 })
+
+tape('test invite.accept publishes new "pub" msg if same pub at different address', function (t) {
+  var alice = Server({ allowPrivate: true })
+  var bob = Server()
+
+  // request a secret that with particular permissions.
+  alice.invite.create(2, function (err, invite) {
+    if (err) throw err
+    bob.invite.accept(invite, function (err) {
+      t.error(err, 'invite accepted')
+
+      const mutatedInvite = mutateInviteDomain(invite)
+      if (invite === mutatedInvite) t.fail('failed to mutate invite')
+
+      bob.invite.accept(mutatedInvite, (err) => {
+        t.error(err, 'accepts invite because its at a different address')
+
+        alice.friends.hops(alice.id, (err, hops) => {
+          if (err) throw err
+          t.equal(hops[bob.id], 1, 'alice follows bob')
+
+          all(bob.messagesByType('pub'), function (err, arr) {
+            if (err) throw err
+
+            t.deepEqual(
+              arr.map(m => m.value.content.address),
+              [
+                ref.parseAddress(invite.split('~')[0]),
+                ref.parseAddress(mutatedInvite.split('~')[0])
+              ],
+              'records both pub locations'
+            )
+
+            // console.log(hops)
+            alice.close(true)
+            bob.close(true)
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+function mutateInviteDomain (invite) {
+  if (invite.match(/^\d{4}:/)) { // ipv6
+    return '127.0.0.1' + invite.slice(39)
+  }
+
+  const ipv4Pattern = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+  if (invite.match(ipv4Pattern)) { // ipv4
+    return invite.replace(ipv4Pattern, 'localhost')
+  }
+
+  if (invite.startsWith('localhost')) {
+    return invite.replace('localhost', '127.0.0.1')
+  }
+
+  throw new Error('cant mutate invite ' + invite)
+}
 
 tape('test invite.accept api with ipv6', { skip: skipIPv6 }, function (t) {
   var alice = Server({ allowPrivate: true })


### PR DESCRIPTION
**problem**: we have a situation where a pub has been moved. The original invites used  a fixed IP address (which is no longer valid), while newer ones use a domain name (which is easier to keep valid as underlying IP changes). Currently if a person who used an old invite doesn't know where the pub is now located. **if they try to use a new invite, it's rejected because _they already follow that pub_**. 

**solution**: if an invite is used for the same pub and it's a valid invite, but they already follow, change this to not be an error. Also, always announce the pub location in this case.

unwanted side effect - if a person uses an invite for a pub at the same host location twice, this will result in two identical `pub` messages being published. Meh, don't care